### PR TITLE
Fix measure and faster validation check

### DIFF
--- a/perf.js
+++ b/perf.js
@@ -9,13 +9,13 @@ const jsonData = fs.readFileSync('./perf/jest-cache.json', 'utf-8');
 const bserData = fs.readFileSync('./perf/jest-cache.bser');
 
 function measure(callback, times = 10) {
-  let avg = 0;
+  let elapsed = 0;
   for (var i = 0; i < times; i++) {
     const start = Date.now();
     callback();
-    avg = (avg + Date.now() - start) / (avg ? 2 : 1);
+    elapsed = Date.now() - start;
   }
-  return avg;
+  return elapsed / times;
 };
 
 
@@ -23,4 +23,7 @@ console.log('json', measure(() => JSON.parse(jsonData)));
 console.log('bserc', measure(() => bserc.loads(bserData)));
 console.log('bser', measure(() => bser.loadFromBuffer(bserData)));
 
-assert.deepEqual(bserc.loads(bserData), JSON.parse(jsonData));
+assert.equal(
+  JSON.stringify(bserc.loads(bserData)),
+  JSON.stringify(JSON.parse(jsonData))
+);


### PR DESCRIPTION
You can't average things like this. You want to sum everything upfront and divide at the end.
Also, assert.deepEqual takes dozens of seconds for me, doing a diff on the stringified version is instant.